### PR TITLE
Reposition app name and nav menu

### DIFF
--- a/dinostat/src/index.css
+++ b/dinostat/src/index.css
@@ -10,7 +10,7 @@
 
 .header {
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
     background-color: var(--header-color);
     padding: 1rem;
@@ -18,8 +18,8 @@
 
 .menu {
     position: absolute;
-    left: 0;
-    padding-left: 1rem;
+    right: 0;
+    padding-right: 1rem;
 }
 
 /* Replace with image and set size */


### PR DESCRIPTION
I have repositioned the items in the header as discussed in the sprint review

- Navigation menu (Hamburger menu) moved to the right
- App name moved to the left