### PR TITLE
Fix nav bar closing on large screens

### DIFF
--- a/dinostat/src/Components/Header.jsx
+++ b/dinostat/src/Components/Header.jsx
@@ -1,11 +1,22 @@
-import { React, useState } from 'react';
+import { React, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
 export default function Header() {
+  const [width, setWidth] = useState(window.innerWidth);
+
+  const updateDimensions = () => {
+    setWidth(window.innerWidth);
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', updateDimensions);
+    return () => window.removeEventListener('resize', updateDimensions);
+  }, []);
+
   const [isOpen, setIsOpen] = useState(false);
 
   const navDisplay = () => {
-    if (isOpen || window.innerWidth > 1250) {
+    if (isOpen || width > 1250) {
       return 'flex';
     }
     return 'none';
@@ -17,7 +28,7 @@ export default function Header() {
 
   return (
     <div>
-      <div className="header">
+      <div className="header bg-[#003B49]">
         <div className="menu">
           <button type="button" onClick={toggle}>
             =
@@ -25,14 +36,13 @@ export default function Header() {
         </div>
 
         <div className="app-name">
-          <h1>DinoStat</h1>
+          <h1 className="text-[#D6D2C4]"><Link to="/"> DinoStat </Link></h1>
         </div>
 
         <div className="nav-links" style={{ display: navDisplay() }}>
           <ul className="nav-list">
-            <li className="link-item"><Link to="/"> Home </Link></li>
-            <li className="link-item"><Link to="/dinosaurs"> Dinosaur List </Link></li>
-            <li className="link-item"><Link to="/charts"> Charts </Link></li>
+            <li className="link-item text-[#D6D2C4]"><Link to="/dinosaurs"> Dinosaur List </Link></li>
+            <li className="link-item text-[#D6D2C4]"><Link to="/charts"> Charts </Link></li>
           </ul>
         </div>
       </div>

--- a/dinostat/src/Components/Header.jsx
+++ b/dinostat/src/Components/Header.jsx
@@ -5,7 +5,7 @@ export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
 
   const navDisplay = () => {
-    if (isOpen || window.innerWidth > 768) {
+    if (isOpen || window.innerWidth > 1250) {
       return 'flex';
     }
     return 'none';

--- a/dinostat/src/index.css
+++ b/dinostat/src/index.css
@@ -182,6 +182,7 @@ b {
     }
 
     .nav-links {
+        display: flex;
         position: relative;
         top: 0;
         width: 40%; /* Place nav links in the side */


### PR DESCRIPTION
The bug that caused the nav bar to not appear on large screens when it was previously closed using the hamburger menu on smaller screens is now fixed.

Use hooks to check for window width instead of window.innerwidth